### PR TITLE
RDKB-55351: [HUB6][64Bit Arch] RdkPppManager crash on bootup

### DIFF
--- a/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
+++ b/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
@@ -592,6 +592,7 @@ PppDmlGetIntfValuesFromPSM
 
     // init mutex
     pthread_mutexattr_t     muttex_attr;
+    memset(&muttex_attr, 0, sizeof(pthread_mutexattr_t));
     pthread_mutexattr_settype(&muttex_attr, PTHREAD_MUTEX_RECURSIVE);
     pthread_mutex_init(&(pEntry->mDataMutex), &(muttex_attr));
 


### PR DESCRIPTION
Reason for change: Fix the crash by initializing the mutex_attr object initialisation.

Test Procedure: Make sure no pppmanager crash on bootup

Change-Id: I434bb2dc18be78d48331d22aab87b55d6cd99680 Priority:P1
Risks:Low
Signed-off-by: Vysakh A V <vysakh.venugopal@sky.uk>
(cherry picked from commit 8f151abe99b6c4288b5e2bb002678552004b37a5)