### PR TITLE
RDKBDEV-2755 : Update WAN and Virtual Interface Selection Logic.

### DIFF
--- a/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
+++ b/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
@@ -231,6 +231,21 @@ static int PppMgr_GetWanIfaceInstance (UINT InstanceNumber, int * WanIfaceInstan
     // for each Wan Interface
     for (iIfaceCount = 1; iIfaceCount <= iTotalNoofEntries; iIfaceCount++)
     {
+#if defined(WAN_MANAGER_UNIFICATION_ENABLED)
+	// get Selection Status
+	snprintf(acTmpQueryParam, sizeof(acTmpQueryParam),WAN_INTERFACE_SELECTION_STATUS, iIfaceCount);
+	if (ANSC_STATUS_FAILURE == DmlPppMgrGetParamValues(WAN_COMPONENT_NAME, WAN_DBUS_PATH, acTmpQueryParam, acTmpReturnValue))
+        {
+            CcspTraceError(("%s %d Failed to get param value %s\n", __FUNCTION__, __LINE__, acTmpQueryParam));
+            return ANSC_STATUS_FAILURE;
+        }
+
+	CcspTraceInfo(("%s %d -  Wan Instance %d is %s\n", __FUNCTION__, __LINE__, iIfaceCount, acTmpReturnValue));
+	if (strcmp(acTmpReturnValue,"Selected") != 0)
+        {
+            continue;
+        }
+#endif
         // get total no of VirtualInterface
         snprintf(acTmpQueryParam, sizeof(acTmpQueryParam), WAN_NO_OF_VIRTUAL_IFACE_PARAM_NAME, iIfaceCount);
         if (ANSC_STATUS_FAILURE == DmlPppMgrGetParamValues(WAN_COMPONENT_NAME, WAN_DBUS_PATH, acTmpQueryParam, acTmpReturnValue))

--- a/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.h
+++ b/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.h
@@ -82,6 +82,7 @@
 #define WAN_NOE_PARAM_NAME    "Device.X_RDK_WanManager.InterfaceNumberOfEntries"
 #define WAN_PHY_PATH_PARAM_NAME    "Device.X_RDK_WanManager.Interface.%d.BaseInterface"
 #define WAN_IFACE_NAME             "Device.X_RDK_WanManager.Interface.%d.VirtualInterface.1.Name"
+#define WAN_INTERFACE_SELECTION_STATUS  "Device.X_RDK_WanManager.Interface.%d.Selection.Status"
 #else
 #define PPP_LCP_STATUS_PARAM_NAME    "Device.X_RDK_WanManager.CPEInterface.%d.PPP.LCPStatus"
 #define PPP_LINK_STATUS_PARAM_NAME    "Device.X_RDK_WanManager.CPEInterface.%d.PPP.LinkStatus"


### PR DESCRIPTION
Reason for change:
WAN instance and Vlan Instance  was not selected based on Selection.Status.

Test Procedure: Sanity test.
Risks: None.