### PR TITLE
RDKBDEV-2764 : Device.PPP.Interface.1.MaxMRUSize DMs is not updated as  per the PSM config

### DIFF
--- a/source/TR-181/middle_layer_src/pppmgr_dml.c
+++ b/source/TR-181/middle_layer_src/pppmgr_dml.c
@@ -626,8 +626,6 @@ Interface_GetParamUlongValue
     if( AnscEqualString(ParamName, "MaxMRUSize", TRUE))
     {
         /* collect value */
-        syscfg_get(NULL, "MaxMRUSize",buff, sizeof(buff));
-        pEntry->Cfg.MaxMRUSize = atoi(buff);
         *puLong = pEntry->Cfg.MaxMRUSize;
 
         retStatus = TRUE;
@@ -1012,9 +1010,6 @@ Interface_SetParamUlongValue
         retStatus = FALSE;
 #else
         pEntry->Cfg.MaxMRUSize = uValue;
-        snprintf(buf,sizeof(buf),"%d",uValue);
-        set_syscfg(buf,"MaxMRUSize");
-
         retStatus = TRUE;
 #endif
     }


### PR DESCRIPTION
Reason for change:
Device.PPP.Interface.1.MaxMRUSize DMs is not updated as per the PSM config

Test Procedure: MaxMRUSize is updated as per PSM.
Risks: None.
Signed-off-by: K Sanjay Nayak <k-sanjay.nayak@t-systems.com>