### PR TITLE
RDKBDEV-2733 : Fix error after enabling -Werror and -Wall in RdkPPPManager

### DIFF
--- a/source/PppManager/pppmgr_global.h
+++ b/source/PppManager/pppmgr_global.h
@@ -35,24 +35,11 @@
 #ifndef  _PPPMGR_GLOBAL_
 #define  _PPPMGR_GLOBAL_
 
-
-#ifdef _ALMIB_EXPORTS
-#define ANSC_EXPORT_API                                __declspec(dllexport)
-#else
-#define ANSC_EXPORT_API                                __declspec(dllimport)
-#endif
-
-
-#ifdef _ANSC_LINUX
-#define ANSC_EXPORT_API
-#endif
-
-
 #include <stdio.h>
 #include <time.h>
 #include "ccsp_trace.h"
 #include "ansc_status.h"
-#include "ansc_debug_wrapper_base.h"
+#include "ansc_platform.h"
 #include "ansc_common_structures.h"
 #include "cosa_plugin_api.h"
 #include "slap_definitions.h"

--- a/source/PppManager/pppmgr_ssp_action.c
+++ b/source/PppManager/pppmgr_ssp_action.c
@@ -47,8 +47,6 @@ extern  ULONG                            g_ulAllocatedSizePeak;
 
 ANSC_STATUS ssp_create()
 {
-    int rc = ANSC_STATUS_FAILURE;
-
     g_pComponentCommonPppManager = (PCOMPONENT_COMMON_PPP_MANAGER) AnscAllocateMemory(sizeof(COMPONENT_COMMON_PPP_MANAGER));
 
     if(!g_pComponentCommonPppManager)

--- a/source/PppManager/pppmgr_ssp_main.c
+++ b/source/PppManager/pppmgr_ssp_main.c
@@ -33,6 +33,12 @@
  */
 
 #include "pppmgr_global.h"
+#include "execinfo.h"
+#include "ccsp_dm_api.h"
+
+#ifdef INCLUDE_BREAKPAD
+#include "breakpad_wrapper.h"
+#endif
 
 #define DEBUG_INI_NAME  "/etc/debug.ini"
 
@@ -44,7 +50,6 @@ extern ANSC_STATUS PppMgr_Init();
 #if defined(_ANSC_LINUX)
 static void daemonize(void) 
 {
-    int fd;
     switch (fork()) {
         case 0:
             break;
@@ -65,6 +70,7 @@ static void daemonize(void)
     }
 
 #ifndef  _DEBUG
+    int fd;
     fd = open("/dev/null", O_RDONLY);
     if (fd != 0) {
         dup2(fd, 0);
@@ -215,7 +221,6 @@ int main(int argc, char* argv[])
 {
     BOOL                bRunAsDaemon = TRUE;
     int                 idx = 0;
-    int                 ind = -1;
     int                 cmdChar            = 0;
     int                 err;
     char                *subSys = NULL;
@@ -302,7 +307,7 @@ int main(int argc, char* argv[])
 
     if(ANSC_STATUS_FAILURE == PppMgr_Init())
     {
-        fprintf(stderr, "PPP Manager Initiliasation Failed: %s\n", Cdm_StrError(err));
+        fprintf(stderr, "PPP Manager Initialisation Failed: %s\n", Cdm_StrError(err));
 
         bPPPIniatilized = FALSE;
     }

--- a/source/PppManager/pppmgr_ssp_messagebus_interface.c
+++ b/source/PppManager/pppmgr_ssp_messagebus_interface.c
@@ -94,7 +94,7 @@ ssp_Mbi_MessageBusEngage
                 component_id,
                 config_file,
                 &bus_handle,
-                Ansc_AllocateMemory_Callback,           /* mallocfc, use default */
+                (CCSP_MESSAGE_BUS_MALLOC)Ansc_AllocateMemory_Callback,           /* mallocfc, use default */
                 Ansc_FreeMemory_Callback                /* freefc,   use default */
             );
 
@@ -105,7 +105,7 @@ ssp_Mbi_MessageBusEngage
         return returnStatus;
     }
 
-    CcspTraceInfo(("INFO: bus_handle: 0x%8x \n", bus_handle));
+    CcspTraceInfo(("INFO: bus_handle: 0x%8p \n", bus_handle));
     g_MessageBusHandle_Irep = bus_handle;
     AnscCopyString(g_SubSysPrefix_Irep, g_Subsystem);
 
@@ -142,7 +142,7 @@ ssp_Mbi_MessageBusEngage
 
     if ( returnStatus != CCSP_Message_Bus_OK )
     {
-        CcspTraceError((" !!! CCSP_Message_Bus_Register_Path ERROR returnStatus: %d\n!!!\n", returnStatus));
+        CcspTraceError((" !!! CCSP_Message_Bus_Register_Path ERROR returnStatus: %ld\n!!!\n", returnStatus));
 
         return returnStatus;
     }
@@ -159,7 +159,7 @@ ssp_Mbi_MessageBusEngage
 
     if ( returnStatus != CCSP_Message_Bus_OK )
     {
-         CcspTraceError((" !!! CCSP_Message_Bus_Register_Event: CurrentSessionIDSignal ERROR returnStatus: %d!!!\n", returnStatus));
+         CcspTraceError((" !!! CCSP_Message_Bus_Register_Event: CurrentSessionIDSignal ERROR returnStatus: %ld!!!\n", returnStatus));
 
         return returnStatus;
     }

--- a/source/TR-181/middle_layer_src/pppmgr_data.c
+++ b/source/TR-181/middle_layer_src/pppmgr_data.c
@@ -67,7 +67,6 @@ BackEndManagerCreate
         VOID
     )
 {
-    ANSC_STATUS                returnStatus = ANSC_STATUS_SUCCESS;
     PBACKEND_MANAGER_OBJECT    pMyObject    = (PBACKEND_MANAGER_OBJECT)NULL;
 
     /*

--- a/source/TR-181/middle_layer_src/pppmgr_dml.c
+++ b/source/TR-181/middle_layer_src/pppmgr_dml.c
@@ -252,27 +252,27 @@ PPP_GetParamStringValue
 
         if (flag & DML_PPP_SUPPORTED_NCP_ATCP)
         {
-            strncat(pValue, "ATCP,",sizeof("ATCP,"));
+            strcat(pValue, "ATCP,");
         }
 
         if (flag & DML_PPP_SUPPORTED_NCP_IPCP)
         {
-            strncat(pValue, "IPCP,",sizeof("IPCP,"));
+            strcat(pValue, "IPCP,");
         }
 
         if (flag & DML_PPP_SUPPORTED_NCP_IPXCP)
         {
-            strncat(pValue, "IPXCP,",sizeof("IPXCP,"));
+            strcat(pValue, "IPXCP,");
         }
 
         if (flag & DML_PPP_SUPPORTED_NCP_NBFCP)
         {
-            strncat(pValue, "NBFCP,",sizeof("NBFCP,"));
+            strcat(pValue, "NBFCP,");
         }
 
         if (flag & DML_PPP_SUPPORTED_NCP_IPv6CP)
         {
-            strncat(pValue, "IPv6CP,",sizeof("IPv6CP,"));
+            strcat(pValue, "IPv6CP,");
         }
 
         return 0;
@@ -334,7 +334,6 @@ Interface_GetEntryCount
         ANSC_HANDLE                 hInsContext
     )
 {
-      ULONG        uiTotalIfaces ;
       return DmlGetTotalNoOfPPPInterfaces(NULL);
 }
 
@@ -509,7 +508,6 @@ Interface_GetParamUlongValue
     PDML_PPP_IF_FULL           pEntry                  = (PDML_PPP_IF_FULL)hInsContext;
 
     BOOL retStatus = FALSE;
-    char buff[10] = {0};
 
     pthread_mutex_lock(&pEntry->mDataMutex);
     /* check the parameter name and return the corresponding value */
@@ -732,7 +730,6 @@ Interface_GetParamStringValue
     )
 {
     PDML_PPP_IF_FULL           pEntry                  = (PDML_PPP_IF_FULL)hInsContext;
-    PUCHAR                          pString                 = NULL;
     uint32_t retStatus = -1;
 
     pthread_mutex_lock(&pEntry->mDataMutex);
@@ -824,15 +821,7 @@ Interface_SetParamBoolValue
     )
 {
     PDML_PPP_IF_FULL           pEntry                  = (PDML_PPP_IF_FULL)hInsContext;
-
-    char command[1024] = { 0 };
-    char config_command[1024] = { 0 };
-    char service_name[256] = { 0 };
-    char auth_proto[8] = { 0 };
-    pthread_t pppdThreadId;
-    BOOL retStatus = FALSE;
-    uint32_t getAttempts = 0;
-    uint32_t waitTime = 0;
+    bool retStatus = TRUE;
 
     if(pEntry == NULL)
     {
@@ -981,7 +970,7 @@ Interface_SetParamUlongValue
     {
         /* save update to backup */
         pEntry->Cfg.AutoDisconnectTime = uValue;
-        snprintf(buf, sizeof(buf), "sleep %d && pppoe-stop &",pEntry->Cfg.AutoDisconnectTime);
+        snprintf(buf, sizeof(buf), "sleep %ld && pppoe-stop &",pEntry->Cfg.AutoDisconnectTime);
         system(buf);
         retStatus = TRUE;
     }
@@ -1237,11 +1226,9 @@ Interface_Commit
         ANSC_HANDLE                 hInsContext
     )
 {
-    PDATAMODEL_PPP             pMyObject               = (PDATAMODEL_PPP      )g_pBEManager->hPPP;
-
     PDML_PPP_IF_FULL           pEntry                  = (PDML_PPP_IF_FULL    )hInsContext;
     pthread_mutex_lock(&pEntry->mDataMutex);
-        PppDmlSetIfCfg(NULL, &pEntry->Cfg);
+    PppDmlSetIfCfg(NULL, &pEntry->Cfg);
     pthread_mutex_unlock(&pEntry->mDataMutex);    
 
     return 0;
@@ -1789,11 +1776,10 @@ PPPoE_Commit
         ANSC_HANDLE                 hInsContext
     )
 {
-    PDATAMODEL_PPP             pMyObject               = (PDATAMODEL_PPP      )g_pBEManager->hPPP;
     PDML_PPP_IF_FULL           pEntry                  = (PDML_PPP_IF_FULL    )hInsContext;
 
     pthread_mutex_lock(&pEntry->mDataMutex);
-        PppDmlSetIfCfg(NULL, &pEntry->Cfg);
+    PppDmlSetIfCfg(NULL, &pEntry->Cfg);
     pthread_mutex_unlock(&pEntry->mDataMutex);
    
     return 0;
@@ -2408,7 +2394,6 @@ IPCP_Commit
         ANSC_HANDLE                 hInsContext
     )
 {
-    PDATAMODEL_PPP             pMyObject               = (PDATAMODEL_PPP      )g_pBEManager->hPPP;
     PDML_PPP_IF_FULL           pEntry                  = (PDML_PPP_IF_FULL    )hInsContext;
 
     pthread_mutex_lock(&pEntry->mDataMutex);

--- a/source/TR-181/middle_layer_src/pppmgr_dml.h
+++ b/source/TR-181/middle_layer_src/pppmgr_dml.h
@@ -42,15 +42,15 @@
 #define DML_PPP_SUPPORTED_NCP_NBFCP  0x08
 #define DML_PPP_SUPPORTED_NCP_IPv6CP 0x10
 #define PSM_PPPMANAGER_PPPIFCOUNT     "dmsb.pppmanager.pppifcount"
-#define PSM_PPP_IF_SERVICE_NAME       "dmsb.pppmanager.if.%d.ServiceName"
-#define PSM_PPP_IF_NAME               "dmsb.pppmanager.if.%d.Name"
-#define PSM_PPP_IF_ALIAS              "dmsb.pppmanager.if.%d.Alias"
-#define PSM_PPP_AUTH_PROTOCOL         "dmsb.pppmanager.if.%d.AuthenticationProtocol"
-#define PSM_PPP_LAST_COONECTION_ERROR "dmsb.pppmanager.if.%d.lastconnectionerror"
-#define PSM_PPP_IDLETIME              "dmsb.pppmanager.if.%d.idletime"
-#define PSM_PPP_MAXMRUSIZE            "dmsb.pppmanager.if.%d.maxmrusize"
-#define PSM_PPP_LINK_TYPE             "dmsb.pppmanager.if.%d.linktype"
-#define PSM_PPP_LOWERLAYERS           "dmsb.pppmanager.if.%d.LowerLayer"
+#define PSM_PPP_IF_SERVICE_NAME       "dmsb.pppmanager.if.%ld.ServiceName"
+#define PSM_PPP_IF_NAME               "dmsb.pppmanager.if.%ld.Name"
+#define PSM_PPP_IF_ALIAS              "dmsb.pppmanager.if.%ld.Alias"
+#define PSM_PPP_AUTH_PROTOCOL         "dmsb.pppmanager.if.%ld.AuthenticationProtocol"
+#define PSM_PPP_LAST_COONECTION_ERROR "dmsb.pppmanager.if.%ld.lastconnectionerror"
+#define PSM_PPP_IDLETIME              "dmsb.pppmanager.if.%ld.idletime"
+#define PSM_PPP_MAXMRUSIZE            "dmsb.pppmanager.if.%ld.maxmrusize"
+#define PSM_PPP_LINK_TYPE             "dmsb.pppmanager.if.%ld.linktype"
+#define PSM_PPP_LOWERLAYERS           "dmsb.pppmanager.if.%ld.LowerLayer"
 
 #ifdef PPP_USERNAME_PASSWORD_FROM_PSM
 #define PSM_PPP_USERNAME              "dmsb.pppmanager.if.%ld.username"

--- a/source/TR-181/middle_layer_src/pppmgr_dml_plugin_main.c
+++ b/source/TR-181/middle_layer_src/pppmgr_dml_plugin_main.c
@@ -86,16 +86,12 @@ int PppManagerDmlInit
     COSASetParamValueBoolProc       pSetParamValueBoolProc      = (COSASetParamValueBoolProc         )NULL;
     COSAGetInstanceNumbersProc      pGetInstanceNumbersProc     = (COSAGetInstanceNumbersProc        )NULL;
 
-    COSAGetCommonHandleProc         pGetCHProc                  = (COSAGetCommonHandleProc           )NULL;
     COSAValidateHierarchyInterfaceProc 
                                     pValInterfaceProc           = (COSAValidateHierarchyInterfaceProc)NULL;
     COSAGetHandleProc               pGetRegistryRootFolder      = (COSAGetHandleProc                 )NULL;
     COSAGetInstanceNumberByIndexProc
                                     pGetInsNumberByIndexProc    = (COSAGetInstanceNumberByIndexProc  )NULL;
-    COSAGetHandleProc               pGetMessageBusHandleProc    = (COSAGetHandleProc                 )NULL;
     COSAGetInterfaceByNameProc      pGetInterfaceByNameProc     = (COSAGetInterfaceByNameProc        )NULL;
-    ULONG                           ret                         = 0;
-    int        rc = -1;
 
     if ( uMaxVersionSupported < THIS_PLUGIN_VERSION )
     {
@@ -146,7 +142,7 @@ int PppManagerDmlInit
         goto EXIT;
     }
 
-    pGetParamValueIntProc = (COSAGetParamValueUlongProc)pPlugInfo->AcquireFunction("COSAGetParamValueInt");
+    pGetParamValueIntProc = (COSAGetParamValueIntProc)pPlugInfo->AcquireFunction("COSAGetParamValueInt");
 
     if( pGetParamValueIntProc != NULL)
     {
@@ -279,7 +275,7 @@ int PppManagerDmlInit
         goto EXIT;
     }
     /* Get Message Bus Handle */
-    g_GetMessageBusHandle = (PFN_CCSPCCDM_APPLY_CHANGES)pPlugInfo->AcquireFunction("COSAGetMessageBusHandle");
+    g_GetMessageBusHandle = (COSAGetHandleProc)pPlugInfo->AcquireFunction("COSAGetMessageBusHandle");
     if ( g_GetMessageBusHandle == NULL )
     {
         goto EXIT;
@@ -297,7 +293,7 @@ int PppManagerDmlInit
     {
         char*   tmpSubsystemPrefix;
         
-        if ( tmpSubsystemPrefix = g_GetSubsystemPrefix(g_pDslhDmlAgent) )
+        if (( tmpSubsystemPrefix = g_GetSubsystemPrefix(g_pDslhDmlAgent)))
         {
             AnscCopyString(g_SubSysPrefix_Irep, tmpSubsystemPrefix);
         }

--- a/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
+++ b/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
@@ -177,7 +177,7 @@ bool PppMgr_EnableIf (UINT InstanceNumber, bool Enable)
         CcspTraceInfo(("%s %d: Handling PPP client start for instance %d\n", __FUNCTION__, __LINE__, InstanceNumber));
         if (PppMgr_SendPppdStartEventToQ(InstanceNumber) != ANSC_STATUS_SUCCESS)
         {
-            CcspTraceInfo(("%d %s: posting PPPMGR_EXEC_PPP_CLIENT event to Q failed for instance %d\n", __FUNCTION__, __LINE__, InstanceNumber));
+            CcspTraceInfo(("%s %d: posting PPPMGR_EXEC_PPP_CLIENT event to Q failed for instance %d\n", __FUNCTION__, __LINE__, InstanceNumber));
             return false;
         }
     }
@@ -186,7 +186,7 @@ bool PppMgr_EnableIf (UINT InstanceNumber, bool Enable)
         CcspTraceInfo (("%s %d: disabling PPP client on instance %d\n", __FUNCTION__, __LINE__, InstanceNumber));
         if (PppMgr_StopPppClient(InstanceNumber) != ANSC_STATUS_SUCCESS)
         {
-            CcspTraceInfo(("%d %s: failed to stop ppp client on instace %d\n", __FUNCTION__, __LINE__, InstanceNumber));
+            CcspTraceInfo(("%s %d: failed to stop ppp client on instace %d\n", __FUNCTION__, __LINE__, InstanceNumber));
             return false;
         }
     }
@@ -351,7 +351,7 @@ PppMgr_StartPppClient (UINT InstanceNumber)
                     pEntry->Cfg.Password, auth_proto, pEntry->Cfg.Alias);
 #else
                 /* Assume a default rp-pppoe config exist. Update rp-pppoe configuration */
-                ret =  snprintf(config_command, sizeof(config_command), "pppoe_config.sh %s %s %s %s PPPoA %d %d",
+                ret =  snprintf(config_command, sizeof(config_command), "pppoe_config.sh %s %s %s %s PPPoA %ld %ld",
                         pEntry->Cfg.Username, pEntry->Cfg.Password, pEntry->Info.InterfaceServiceName, pEntry->Info.Name, pEntry->Info.LCPEcho, pEntry->Info.LCPEchoRetry);
                 if(ret > 0 && ret <= sizeof(config_command))
                 {
@@ -385,7 +385,7 @@ PppMgr_StartPppClient (UINT InstanceNumber)
                 }
 
                 /* Assume a defule rp-pppoe config exist. Update rp-pppoe configuration */
-                ret = snprintf(config_command, sizeof(config_command), "pppoe_config.sh '%s' '%s' %s %s PPPoE %d %d %d ",
+                ret = snprintf(config_command, sizeof(config_command), "pppoe_config.sh '%s' '%s' %s %s PPPoE %ld %ld %d ",
                         pEntry->Cfg.Username, pEntry->Cfg.Password, VLANInterfaceName, pEntry->Info.Name, pEntry->Info.LCPEcho , pEntry->Info.LCPEchoRetry,pEntry->Cfg.MaxMRUSize);
                 if(ret > 0 && ret <= sizeof(config_command))
                 {
@@ -455,16 +455,16 @@ ANSC_STATUS PppMgr_StopPppClient (UINT InstanceNumber)
 
 ANSC_STATUS PppDmlIfReset (ULONG InstanceNumber )
 {
-    CcspTraceInfo (("%s %d: disabling PPP client on instance %d\n", __FUNCTION__, __LINE__, InstanceNumber));
+    CcspTraceInfo (("%s %d: disabling PPP client on instance %ld\n", __FUNCTION__, __LINE__, InstanceNumber));
     if (PppMgr_StopPppClient(InstanceNumber) != ANSC_STATUS_SUCCESS)
     {
-        CcspTraceInfo(("%d %s: failed to stop ppp client on instace %d\n", __FUNCTION__, __LINE__, InstanceNumber));
+        CcspTraceInfo(("%s %d: failed to stop ppp client on instance %ld\n", __FUNCTION__, __LINE__, InstanceNumber));
         return false;
     }
-    CcspTraceInfo(("%s %d: Handling PPP client start for instance %d\n", __FUNCTION__, __LINE__, InstanceNumber));
+    CcspTraceInfo(("%s %d: Handling PPP client start for instance %ld\n", __FUNCTION__, __LINE__, InstanceNumber));
     if (PppMgr_SendPppdStartEventToQ(InstanceNumber) != ANSC_STATUS_SUCCESS)
     {
-        CcspTraceInfo(("%d %s: posting PPPMGR_EXEC_PPP_CLIENT event to Q failed for instance %d\n", __FUNCTION__, __LINE__, InstanceNumber));
+        CcspTraceInfo(("%s %d: posting PPPMGR_EXEC_PPP_CLIENT event to Q failed for instance %ld\n", __FUNCTION__, __LINE__, InstanceNumber));
         return false;
     }
     return true;
@@ -514,28 +514,27 @@ int PppMgr_RdkBus_SetParamValuesToDB( char *pParamName, char *pParamVal )
     return retPsmSet;
 }
 
-static int PppManager_SetParamFromPSM(PDML_PPP_IF_FULL pEntry)
+static int PppManager_SetParamFromPSM(PDML_PPP_IF_CFG pEntry)
 {
-    int retPsmSet = CCSP_SUCCESS;
     char param_name[256] = {0};
     char param_value[256] = {0};
-    int instancenum = 0;
+    ULONG instancenum = 0;
 
-    instancenum = pEntry->Cfg.InstanceNumber;
+    instancenum = pEntry->InstanceNumber;
 
-    CcspTraceWarning(("%s-%d:instancenum=%d \n",__FUNCTION__, __LINE__, instancenum));
+    CcspTraceWarning(("%s-%d:instancenum=%ld \n",__FUNCTION__, __LINE__, instancenum));
 
     memset(param_value, 0, sizeof(param_value));
     memset(param_name, 0, sizeof(param_name));
 
-    snprintf(param_value, sizeof(param_name), "%d", pEntry->Cfg.IdleDisconnectTime);
+    snprintf(param_value, sizeof(param_name), "%ld", pEntry->IdleDisconnectTime);
     snprintf(param_name, sizeof(param_name), PSM_PPP_IDLETIME, instancenum);
     PppMgr_RdkBus_SetParamValuesToDB(param_name,param_value);
 
     memset(param_value, 0, sizeof(param_value));
     memset(param_name, 0, sizeof(param_name));
 	
-    snprintf(param_value, sizeof(param_value), "%d", pEntry->Cfg.MaxMRUSize);
+    snprintf(param_value, sizeof(param_value), "%d", pEntry->MaxMRUSize);
     snprintf(param_name, sizeof(param_name), PSM_PPP_MAXMRUSIZE, instancenum);
     PppMgr_RdkBus_SetParamValuesToDB(param_name,param_value);
 
@@ -543,14 +542,14 @@ static int PppManager_SetParamFromPSM(PDML_PPP_IF_FULL pEntry)
     memset(param_value, 0, sizeof(param_value));
     memset(param_name, 0, sizeof(param_name));
 
-    snprintf(param_value, sizeof(param_value), "%s", pEntry->Cfg.Username);
+    snprintf(param_value, sizeof(param_value), "%s", pEntry->Username);
     snprintf(param_name, sizeof(param_name), PSM_PPP_USERNAME, instancenum);
     PppMgr_RdkBus_SetParamValuesToDB(param_name,param_value);
 
     memset(param_value, 0, sizeof(param_value));
     memset(param_name, 0, sizeof(param_name));
 
-    snprintf(param_value, sizeof(param_value), "%s", pEntry->Cfg.Password);
+    snprintf(param_value, sizeof(param_value), "%s", pEntry->Password);
     snprintf(param_name, sizeof(param_name), PSM_PPP_PASSWORD, instancenum);
     PppMgr_RdkBus_SetParamValuesToDB(param_name,param_value);
 #endif
@@ -809,9 +808,8 @@ ANSC_STATUS PppMgr_stopPppoe(void)
     return ANSC_STATUS_SUCCESS;
 }
 
-static ANSC_STATUS DmlPppMgrGetParamValues(char *pComponent, char *pBus, char *pParamName, char *pReturnVal)
+ANSC_STATUS DmlPppMgrGetParamValues(char *pComponent, char *pBus, char *pParamName, char *pReturnVal)
 {
-    CCSP_MESSAGE_BUS_INFO *bus_info = (CCSP_MESSAGE_BUS_INFO *)bus_handle;
     parameterValStruct_t **retVal;
     char *ParamName[1];
     int ret = 0,
@@ -855,8 +853,8 @@ static ANSC_STATUS DmlPppMgrGetParamValues(char *pComponent, char *pBus, char *p
     return ANSC_STATUS_FAILURE;
 }
 
-ANSC_STATUS DmlWanmanagerSetParamValues(const char *pComponent, const char *pBus,
-        const char *pParamName, const char *pParamVal, enum dataType_e type, unsigned int bCommitFlag)
+ANSC_STATUS DmlWanmanagerSetParamValues(char *pComponent, char *pBus,
+        char *pParamName, char *pParamVal, enum dataType_e type, unsigned int bCommitFlag)
 {
     CCSP_MESSAGE_BUS_INFO *bus_info = (CCSP_MESSAGE_BUS_INFO *)bus_handle;
     parameterValStruct_t param_val[1] = {0};
@@ -873,7 +871,7 @@ ANSC_STATUS DmlWanmanagerSetParamValues(const char *pComponent, const char *pBus
             pBus,
             0,
             0,
-            &param_val,
+            param_val,
             1,
             bCommitFlag,
             &faultParam);
@@ -907,30 +905,6 @@ ULONG GetUptimeinSeconds ()
     return UpTime;
 }
 
-#define PPPOE_PROC_FILE "/proc/net/pppoe"
-static int get_session_id_from_proc_entry(ULONG * p_id)
-{
-    FILE * fp;
-    char buf[1024] = {0};
-    if(fp = fopen(PPPOE_PROC_FILE, "r"))
-    {
-        /* Skip first line of /proc/net/pppoe */
-        /* Id Address Device */
-        fgets(buf, sizeof(buf)-1, fp);
-        while(fgets(buf, sizeof(buf)-1, fp))
-        {
-            unsigned long id = 0L;
-            if(sscanf(buf, "%08X", &id) == 1)
-            {
-                *p_id = ntohs(id);
-                CcspTraceInfo(("PPP Session ID: %08X, %d \n", id, *p_id));
-            }
-        }
-        fclose(fp);
-    }
-    return 0;
-}
-
 static int CosaUtilGetIfStats(char *ifname, PDML_IF_STATS pStats)
 {
     int    i;
@@ -951,12 +925,12 @@ static int CosaUtilGetIfStats(char *ifname, PDML_IF_STATS pStats)
         {
             if(++i <= 2)
                 continue;
-            if(p = strchr(buf, ':'))
+            if((p = strchr(buf, ':')))
             {
                 if(strstr(buf, ifname))
                 {
                     memset(pStats, 0, sizeof(*pStats));
-                    if (sscanf(p+1, "%d %d %d %d %*d %*d %*d %*d %d %d %d %d %*d %*d %*d %*d",
+                    if (sscanf(p+1, "%ld %ld %ld %ld %*d %*d %*d %*d %ld %ld %ld %ld %*d %*d %*d %*d",
                     &pStats->BytesReceived, &pStats->PacketsReceived, &pStats->ErrorsReceived,
                     &pStats->DiscardPacketsReceived,&pStats->BytesSent, &pStats->PacketsSent,
                     &pStats->ErrorsSent, &pStats->DiscardPacketsSent) == 8)

--- a/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.h
+++ b/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.h
@@ -42,6 +42,7 @@
 #include <sys/ioctl.h>
 #include <utapi_util.h>
 #include <mqueue.h>
+#include "ccsp_psm_helper.h"
 
 #define MAXINSTANCE    128
 #define DNS_FILE "/var/run/ppp/resolv.conf"
@@ -140,10 +141,10 @@ ANSC_STATUS PppMgr_stopPppProcess( pid_t pid );
 
 ANSC_STATUS PppMgr_stopPppoe(void);
 
-ANSC_STATUS DmlWanmanagerSetParamValues( const char *pComponent, const char *pBus,
-        const char *pParamName, const char *pParamVal, enum dataType_e type, unsigned int bCommitFlag );
+ANSC_STATUS DmlWanmanagerSetParamValues( char *pComponent, char *pBus,
+        char *pParamName, char *pParamVal, enum dataType_e type, unsigned int bCommitFlag );
 
-static ANSC_STATUS DmlPppMgrGetParamValues(char *pComponent, char *pBus, char *pParamName, char *pReturnVal);
+ANSC_STATUS DmlPppMgrGetParamValues(char *pComponent, char *pBus, char *pParamName, char *pReturnVal);
 
 ULONG GetUptimeinSeconds ();
 
@@ -164,4 +165,20 @@ void PppMgr_GetIfaceData_release (DML_PPP_IF_FULL * pPppTable);
 ANSC_STATUS PppMgr_StopPppClient (UINT InstanceNumber);
 
 int PppMgr_getIfaceDataWithPid (pid_t pid);
+
+ANSC_STATUS PppDmlGetSupportedNCPs (ANSC_HANDLE hContext, PULONG puLong);
+
+int set_syscfg(char *pValue,char *param);
+
+ANSC_STATUS PppDmlGetIfCfg ( ANSC_HANDLE hContext, PDML_PPP_IF_CFG pCfg);
+
+int get_session_id(ULONG * p_id, ANSC_HANDLE hContext);
+
+ANSC_STATUS PppMgr_SendDataToQ (PPPEventQData * pEventData);
+
+pid_t PppMgr_getPppPid(char * ifname);
+
+bool PppMgr_EnableIf (UINT InstanceNumber, bool Enable);
+
+ANSC_STATUS PppMgr_StartPppClient (UINT InstanceNumber);
 #endif

--- a/source/TR-181/middle_layer_src/pppmgr_utils.c
+++ b/source/TR-181/middle_layer_src/pppmgr_utils.c
@@ -106,7 +106,6 @@ PppGetIfAddr
 
 ULONG get_ppp_ip_addr(void)
 {
-    ULONG addr       = 0;
     wanProto_t proto = 0;
     char buf[128]    = {0};
 
@@ -145,7 +144,7 @@ int get_session_id(ULONG * p_id, ANSC_HANDLE hContext)
 
     if(pEntry->Cfg.LinkType == DML_PPPoE_LINK_TYPE)
     {
-        if(fp = fopen(PPPOE_PROC_FILE, "r"))
+        if((fp = fopen(PPPOE_PROC_FILE, "r")))
         {
            /* Skip first line of /proc/net/pppoe */
            /* Id Address Device */
@@ -157,10 +156,10 @@ int get_session_id(ULONG * p_id, ANSC_HANDLE hContext)
               if(strstr(buf, "Id") )
                  continue;
 
-              if(sscanf(buf, "%08X", &id) == 1)
+              if(sscanf(buf, "%08lX", &id) == 1)
               {
                  *p_id = ntohs(id);
-                 CcspTraceInfo(("PPP Session ID: %08X, %d \n", id, *p_id));
+                 CcspTraceInfo(("PPP Session ID: %08lX, %ld \n", id, *p_id));
               }
            }
            fclose(fp);
@@ -175,7 +174,7 @@ int get_session_id(ULONG * p_id, ANSC_HANDLE hContext)
         if (!get_ppp_ip_addr())
             return 0;
 
-        if (fp = fopen(LOG_FILE, "r+"))
+        if ((fp = fopen(LOG_FILE, "r+")))
         {
             while (fgets(buf, sizeof(buf)-1, fp))
             {
@@ -216,7 +215,7 @@ int get_auth_proto(int * p_proto)
     char buf[1024] = {0};
     char result[1024] = {0};
 
-    if (fp = fopen(LOG_FILE, "r+"))
+    if ((fp = fopen(LOG_FILE, "r+")))
     {
         while (fgets(buf, sizeof(buf)-1, fp))
         {


### PR DESCRIPTION
Reason for change:
Fix error after enabling -Werror and -Wall in RdkPPPManager.

Test Procedure: Sanity test.
Risks: None.