### PR TITLE
RDKCOM-4910 : Testing changes for internal validation, not required to merge

### DIFF
--- a/source/TR-181/middle_layer_src/pppmgr_dml.c
+++ b/source/TR-181/middle_layer_src/pppmgr_dml.c
@@ -626,8 +626,6 @@ Interface_GetParamUlongValue
     if( AnscEqualString(ParamName, "MaxMRUSize", TRUE))
     {
         /* collect value */
-        syscfg_get(NULL, "MaxMRUSize",buff, sizeof(buff));
-        pEntry->Cfg.MaxMRUSize = atoi(buff);
         *puLong = pEntry->Cfg.MaxMRUSize;
 
         retStatus = TRUE;
@@ -1012,9 +1010,6 @@ Interface_SetParamUlongValue
         retStatus = FALSE;
 #else
         pEntry->Cfg.MaxMRUSize = uValue;
-        snprintf(buf,sizeof(buf),"%d",uValue);
-        set_syscfg(buf,"MaxMRUSize");
-
         retStatus = TRUE;
 #endif
     }


### PR DESCRIPTION
RDKCOM-4910 RDKBDEV-2764 : Testing changes for internal validation, not required to merge
Reason for change: Testing purpose, do not merge

Test Procedure: MaxMRUSize is updated as per PSM.
Risks: None.
Signed-off-by: K Sanjay Nayak <k-sanjay.nayak@t-systems.com>
(cherry picked from commit a1d472451c39a139b24c2e0db8732f6bf2dee7b8)