### PR TITLE
RDKBDEV-2803 : Avoid free Wlid pointer

### DIFF
--- a/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
+++ b/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
@@ -812,10 +812,10 @@ ANSC_STATUS PppMgr_stopPppoe(void)
 static ANSC_STATUS DmlPppMgrGetParamValues(char *pComponent, char *pBus, char *pParamName, char *pReturnVal)
 {
     CCSP_MESSAGE_BUS_INFO *bus_info = (CCSP_MESSAGE_BUS_INFO *)bus_handle;
-    parameterValStruct_t **retVal;
+    parameterValStruct_t **retVal = NULL;
     char *ParamName[1];
     int ret = 0,
-        nval;
+        nval = 0;
 
     //Assign address for get parameter name
     ParamName[0] = pParamName;


### PR DESCRIPTION
Reason for change:
RdkPppManager sometimes crash
DmlPppMgrGetParamValues will not init retVal and will pass it into CcspBaseIf_getParameterValues as parameterval and then into CcspBaseIf_getParameterValues_rbus. CcspBaseIf_getParameterValues_rbus will not set parameterval when rbus get fail, then a uninitialized pointer will be free in free_parameterValStruct_t. Test Procedure: Not applicable
Risks: None
Signed-off-by: Geoff Lu <geoff_lu@sdc.sercomm.com>