### PR TITLE
RDKCOM-4943 RDKBDEV-2807 : Support ppp auto protocol node

### DIFF
--- a/config/RdkPppManager.xml
+++ b/config/RdkPppManager.xml
@@ -173,7 +173,7 @@ limitations under the License.
             </parameter>
             <parameter>
               <name>AuthenticationProtocol</name>
-              <type>string: PAP(1),CHAP(2),MS-CHAP(3)</type>
+              <type>string: PAP(1),CHAP(2),MS-CHAP(3),AUTO(4)</type>
               <syntax>uint32/mapped</syntax>
             </parameter>
             <parameter>

--- a/source/TR-181/middle_layer_src/pppmgr_dml.h
+++ b/source/TR-181/middle_layer_src/pppmgr_dml.h
@@ -216,7 +216,8 @@ typedef  enum _DML_PPP_AUTH
 {
     DML_PPP_AUTH_PAP                           = 1,
     DML_PPP_AUTH_CHAP,
-    DML_PPP_AUTH_MS_CHAP
+    DML_PPP_AUTH_MS_CHAP,
+    DML_PPP_AUTH_AUTO
 }
 DML_PPP_AUTH, *PDML_PPP_AUTH;
 

--- a/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
+++ b/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
@@ -317,6 +317,8 @@ PppMgr_StartPppClient (UINT InstanceNumber)
 
         switch (pEntry->Info.AuthenticationProtocol)
         {
+            case DML_PPP_AUTH_AUTO:
+                break;
             case DML_PPP_AUTH_PAP:
                 snprintf(auth_proto, sizeof(auth_proto), " require-pap refuse-chap refuse-mschap noauth");
                 break;
@@ -686,9 +688,21 @@ PppDmlGetIntfValuesFromPSM
     retPsmGet = PSM_Get_Record_Value2(bus_handle, g_Subsystem, param_name, NULL, &param_value);
     if (retPsmGet == CCSP_SUCCESS && param_value != NULL)
     {
+        if (strcmp(param_value, "PAP") == 0)
+        {
+            pEntry->Info.AuthenticationProtocol = DML_PPP_AUTH_PAP;
+        }
         if (strcmp(param_value, "CHAP") == 0)
         {
             pEntry->Info.AuthenticationProtocol = DML_PPP_AUTH_CHAP;
+        }
+        if (strcmp(param_value, "MS-CHAP") == 0)
+        {
+            pEntry->Info.AuthenticationProtocol = DML_PPP_AUTH_MS_CHAP;
+        }
+        if (strcmp(param_value, "AUTO") == 0)
+        {
+            pEntry->Info.AuthenticationProtocol = DML_PPP_AUTH_AUTO;
         }
         CcspTraceInfo(("%s %d: from PSM %s = %s\n", __FUNCTION__, __LINE__, param_name, param_value));
     }


### PR DESCRIPTION
Reason for change:
PPP need to special which authentication protocol to use, like PAP, CHAP ... But if ppp server only support one of them, pppd may not connect to ppp server successfully. Add AUTO option to unspecial authentication protocol may be chaotic Support to all authentication protocol in first pppd start to avoid the ppp server that unsupport some authentication protocol Test Procedure:
1. Set psm node value to AUTO
2. Check pppd args, should not include require-xxx refuse-xxx
3. Make ppp wan down and up again
4. Check pppd args, should include require-xxx refuse-xxx Risks: Low
Signed-off-by: Geoff Lu <geoff_lu@sdc.sercomm.com>