### PR TITLE
RDKBDEV-2823 : Send PADT After Bootup Before Starting New PPPoE Session.

### DIFF
--- a/source/PppManager/pppmgr_ipc.c
+++ b/source/PppManager/pppmgr_ipc.c
@@ -480,7 +480,7 @@ static ANSC_STATUS PppMgr_ProcessStateChangedMsg(int InstanceNumber, ipc_ppp_eve
     char WanPppLinkStatus[64] = { 0 };
     uint32_t updatedParam = 0;
     int ret = 0;
-
+    char paramValue[256]   = {0};
 
     if(InstanceNumber <= 0 )
     {
@@ -527,6 +527,11 @@ static ANSC_STATUS PppMgr_ProcessStateChangedMsg(int InstanceNumber, ipc_ppp_eve
                 snprintf(WanPppLinkStatus, sizeof(WanPppLinkStatus), UP);
                 updatedParam = 1;
                 pEntry->Info.LastChange = GetUptimeinSeconds();
+
+                CcspTraceInfo(("[%s-%d] Updating SessionID to PSM : %ld\n", __FUNCTION__, __LINE__, pEntry->Info.SessionID));
+                get_session_id(&pEntry->Info.SessionID, pEntry);
+                sprintf(paramValue, "%d", pEntry->Info.SessionID);
+                PppMgr_RdkBus_SetParamValuesToDB(PSM_PPP_SESSIONID, paramValue);
                 break;
 
             case PPP_INTERFACE_DISCONNECTING:

--- a/source/PppManager/pppmgr_ipc.c
+++ b/source/PppManager/pppmgr_ipc.c
@@ -530,7 +530,7 @@ static ANSC_STATUS PppMgr_ProcessStateChangedMsg(int InstanceNumber, ipc_ppp_eve
 
                 CcspTraceInfo(("[%s-%d] Updating SessionID to PSM : %ld\n", __FUNCTION__, __LINE__, pEntry->Info.SessionID));
                 get_session_id(&pEntry->Info.SessionID, pEntry);
-                sprintf(paramValue, "%d", pEntry->Info.SessionID);
+                sprintf(paramValue, "%ld", pEntry->Info.SessionID);
                 PppMgr_RdkBus_SetParamValuesToDB(PSM_PPP_SESSIONID, paramValue);
                 break;
 

--- a/source/TR-181/middle_layer_src/pppmgr_dml.h
+++ b/source/TR-181/middle_layer_src/pppmgr_dml.h
@@ -51,6 +51,7 @@
 #define PSM_PPP_MAXMRUSIZE            "dmsb.pppmanager.if.%d.maxmrusize"
 #define PSM_PPP_LINK_TYPE             "dmsb.pppmanager.if.%d.linktype"
 #define PSM_PPP_LOWERLAYERS           "dmsb.pppmanager.if.%d.LowerLayer"
+#define PSM_PPP_SESSIONID             "dmsb.pppmanager.if.%d.sessionid"
 
 #ifdef PPP_USERNAME_PASSWORD_FROM_PSM
 #define PSM_PPP_USERNAME              "dmsb.pppmanager.if.%ld.username"

--- a/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
+++ b/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
@@ -400,8 +400,8 @@ PppMgr_StartPppClient (UINT InstanceNumber)
                     fscanf(fp,"%s", ppp_mac_addr);
 
                     /* Send PADT for previous ppp session */
-                    ret = snprintf(padt_command, sizeof(padt_command), "pppoe -I %s -e %d:%s -k", VLANInterfaceName, pEntry->Info.SessionID, ppp_mac_addr);
-                    CcspTraceInfo((" PADT command : pppoe -I %s -e %d:%s -k\n",VLANInterfaceName, pEntry->Info.SessionID, ppp_mac_addr));
+                    ret = snprintf(padt_command, sizeof(padt_command), "pppoe -I %s -e %ld:%s -k", VLANInterfaceName, pEntry->Info.SessionID, ppp_mac_addr);
+                    CcspTraceInfo((" PADT command : pppoe -I %s -e %ld:%s -k\n",VLANInterfaceName, pEntry->Info.SessionID, ppp_mac_addr));
 
                     if(ret > 0 && ret <= sizeof(padt_command))
                     {


### PR DESCRIPTION
Reason for change:
Send PADT at boot to terminate old PPP session and speed time taken for new PPPoE session.

Test Procedure: PADT packet must be sent for previous PPPoE session before starting new session.
Risks: None.