### PR TITLE
RDKB-56513 : Mismatch Between ppp_event_msg Structure in PPPManager and pppd.

### DIFF
--- a/source/PppManager/pppmgr_ipc.c
+++ b/source/PppManager/pppmgr_ipc.c
@@ -864,7 +864,7 @@ static ANSC_STATUS PppMgr_ProcessPppState(ipc_msg_payload_t ipcMsg)
         return ANSC_STATUS_FAILURE;
     }
 
-    CcspTraceInfo(("%s %d: PPP State change message from interface %s from pid = %d\n", __FUNCTION__, __LINE__, ipcMsg.data.pppEventMsg.interface, ipcMsg.data.pppEventMsg.pid));
+    CcspTraceInfo(("%s %d: PPP State change message from pid = %d\n", __FUNCTION__, __LINE__, ipcMsg.data.pppEventMsg.pid));
 
     int InstanceNumber = PppMgr_getIfaceDataWithPid(ipcMsg.data.pppEventMsg.pid);
 


### PR DESCRIPTION
Reason for change:
Mismatch between the ppp_event_msg structure between PPPManager and pppd. interface structure member from IPC structure is used only to identify which PPP interface configuration has been changed. Also that variable is used in PPPManager only for display purpose hence that member is not required. so we have decided to remove that structure member from common library IPC structure since it is not used for functional purpose.

Test Procedure:
1. PPP Manager and PPP deamon version 2.4.8 should work without any issue.
2. WAN connection should work without any issue.

Risks: Low