### PR TITLE
Revert "RDKB-56513 : Mismatch Between ppp_event_msg Structure in PPPManager and pppd."

### DIFF
--- a/source/PppManager/pppmgr_ipc.c
+++ b/source/PppManager/pppmgr_ipc.c
@@ -869,7 +869,7 @@ static ANSC_STATUS PppMgr_ProcessPppState(ipc_msg_payload_t ipcMsg)
         return ANSC_STATUS_FAILURE;
     }
 
-    CcspTraceInfo(("%s %d: PPP State change message from pid = %d\n", __FUNCTION__, __LINE__, ipcMsg.data.pppEventMsg.pid));
+    CcspTraceInfo(("%s %d: PPP State change message from interface %s from pid = %d\n", __FUNCTION__, __LINE__, ipcMsg.data.pppEventMsg.interface, ipcMsg.data.pppEventMsg.pid));
 
     int InstanceNumber = PppMgr_getIfaceDataWithPid(ipcMsg.data.pppEventMsg.pid);
 


### PR DESCRIPTION
Reverts rdkcentral/RdkPppManager#16

Since we need interfacename structure member so keeping current change instead of removing from PPPManager side.