### PR TITLE
RDKCOM-5089 RDKBDEV-2937: drop syscfg_init() as a public API

### DIFF
--- a/source/PppManager/pppmgr_ipc.c
+++ b/source/PppManager/pppmgr_ipc.c
@@ -1106,13 +1106,6 @@ ANSC_STATUS PppMgr_Init()
     }
     CcspTraceInfo(("%s %d - IPC server started successfully!\n", __FUNCTION__, __LINE__ ));
 
-    // Initialise syscfg
-    if (syscfg_init() < 0)
-    {
-        CcspTraceError(("failed to initialise syscfg"));
-        return ANSC_STATUS_FAILURE;
-    }
-
     // Initialize sysevent
     if ( DmlPppSyseventInit( ) < 0 )
     {


### PR DESCRIPTION
Reason for change:
drop syscfg_init() as a public API
Initialisation is now handled automatically with the syscfg lib, so explicit calls to syscfg_init() are no longer required. Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
Signed-off-by: Pradeepta Das <Pradeepta_Das@comcast.com>