### PR TITLE
RDKCOM-5165 RDKBDEV-2733 : Fix Werror in RdkPPPManager.

### DIFF
--- a/source/TR-181/middle_layer_src/pppmgr_dml.h
+++ b/source/TR-181/middle_layer_src/pppmgr_dml.h
@@ -42,16 +42,16 @@
 #define DML_PPP_SUPPORTED_NCP_NBFCP  0x08
 #define DML_PPP_SUPPORTED_NCP_IPv6CP 0x10
 #define PSM_PPPMANAGER_PPPIFCOUNT     "dmsb.pppmanager.pppifcount"
-#define PSM_PPP_IF_SERVICE_NAME       "dmsb.pppmanager.if.%d.ServiceName"
-#define PSM_PPP_IF_NAME               "dmsb.pppmanager.if.%d.Name"
-#define PSM_PPP_IF_ALIAS              "dmsb.pppmanager.if.%d.Alias"
-#define PSM_PPP_AUTH_PROTOCOL         "dmsb.pppmanager.if.%d.AuthenticationProtocol"
-#define PSM_PPP_LAST_COONECTION_ERROR "dmsb.pppmanager.if.%d.lastconnectionerror"
-#define PSM_PPP_IDLETIME              "dmsb.pppmanager.if.%d.idletime"
-#define PSM_PPP_MAXMRUSIZE            "dmsb.pppmanager.if.%d.maxmrusize"
-#define PSM_PPP_LINK_TYPE             "dmsb.pppmanager.if.%d.linktype"
-#define PSM_PPP_LOWERLAYERS           "dmsb.pppmanager.if.%d.LowerLayer"
-#define PSM_PPP_SESSIONID             "dmsb.pppmanager.if.%d.sessionid"
+#define PSM_PPP_IF_SERVICE_NAME       "dmsb.pppmanager.if.%ld.ServiceName"
+#define PSM_PPP_IF_NAME               "dmsb.pppmanager.if.%ld.Name"
+#define PSM_PPP_IF_ALIAS              "dmsb.pppmanager.if.%ld.Alias"
+#define PSM_PPP_AUTH_PROTOCOL         "dmsb.pppmanager.if.%ld.AuthenticationProtocol"
+#define PSM_PPP_LAST_COONECTION_ERROR "dmsb.pppmanager.if.%ld.lastconnectionerror"
+#define PSM_PPP_IDLETIME              "dmsb.pppmanager.if.%ld.idletime"
+#define PSM_PPP_MAXMRUSIZE            "dmsb.pppmanager.if.%ld.maxmrusize"
+#define PSM_PPP_LINK_TYPE             "dmsb.pppmanager.if.%ld.linktype"
+#define PSM_PPP_LOWERLAYERS           "dmsb.pppmanager.if.%ld.LowerLayer"
+#define PSM_PPP_SESSIONID             "dmsb.pppmanager.if.%ld.sessionid"
 
 #ifdef PPP_USERNAME_PASSWORD_FROM_PSM
 #define PSM_PPP_USERNAME              "dmsb.pppmanager.if.%ld.username"

--- a/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
+++ b/source/TR-181/middle_layer_src/pppmgr_dml_ppp_apis.c
@@ -382,7 +382,7 @@ PppMgr_StartPppClient (UINT InstanceNumber)
                 }
 
                 /* Get previous ppp session details */
-                if(fp = fopen("/nvram/last_ppp_session", "r"))
+                if((fp = fopen("/nvram/last_ppp_session", "r")))
                 {
                     fscanf(fp,"%s", ppp_mac_addr);
 


### PR DESCRIPTION
Reason for change:
Fix error after enabling -Werror and -Wall in RdkPPPManager.

Test Procedure: Sanity test.
Risks: None.