### PR TITLE
RDKB-58019 : Adding version log.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,12 @@ AM_CONDITIONAL(CCSP_ARCH_ATOM, test "x$CCSP_ARCH" = xatom)
 AM_CONDITIONAL(CCSP_ARCH_PC, test "x$CCSP_ARCH" = xpc)
 AM_CONDITIONAL(CCSP_ARCH_MIPS, test "x$CCSP_ARCH" = xmips)
 
+#Add git version
+m4_define([GITVERSION],
+  m4_esyscmd_s([git describe --tags --always --dirty 2>/dev/null || echo "undefined"])
+)
+AC_SUBST([GIT_VERSION], [GITVERSION])
+
 # Specify ccsp platform (device)
 
 AC_ARG_WITH([ccsp-platform],

--- a/source/PppManager/Makefile.am
+++ b/source/PppManager/Makefile.am
@@ -43,4 +43,5 @@ pppmanager_CFLAGS = $(SYSTEMD_CFLAGS) $(NONROOT_CFLAGS)
 pppmanager_SOURCES = pppmgr_ssp_action.c pppmgr_ssp_main.c pppmgr_ssp_messagebus_interface.c pppmgr_ipc.c
 pppmanager_LDFLAGS = -lccsp_common -ldl $(SYSTEMD_LDFLAGS) -lrdkloggers -lhal_platform -lnanomsg -lrt
 pppmanager_LDADD =  $(pppmanager_DEPENDENCIES)
+pppmanager_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 

--- a/source/PppManager/pppmgr_ssp_main.c
+++ b/source/PppManager/pppmgr_ssp_main.c
@@ -251,6 +251,7 @@ int main(int argc, char* argv[])
 
     pComponentName          = RDK_COMPONENT_NAME_PPP_MANAGER;
 
+    CcspTraceInfo(("Version : %s \n",GIT_VERSION ));
 #if defined(_ANSC_WINDOWSNT)
     AnscStartupSocketWrapper(NULL);
 


### PR DESCRIPTION
Reason for change:  Adding version log using "git describe --tags --always --dirty" command Example :
RC2.7.0a-1-g5aa0583-dirty
Tag: RC2.7.0a (Most recent tag)
Number of Commits Ahead: -1 (1 commit after the tag) Commit Hash: g5aa0583 ( "5aa0583" Hash of the current commit) Uncommitted Changes: -dirty (Changes not yet committed)

Test Procedure:
Version log should be present.

Priority: P1
Risks: none