### PR TITLE
RDKCOM-5245 RDKBDEV-3075 remove dependency on dbus

### DIFF
--- a/source/PppManager/pppmgr_ssp_messagebus_interface.c
+++ b/source/PppManager/pppmgr_ssp_messagebus_interface.c
@@ -40,36 +40,6 @@ extern ANSC_HANDLE          g_MessageBusHandle_Irep;
 extern char                 g_SubSysPrefix_Irep[32];
 
 #ifdef _ANSC_LINUX
-DBusHandlerResult
-CcspComp_path_message_func
-    (
-        DBusConnection  *conn,
-        DBusMessage     *message,
-        void            *user_data
-    )
-{
-    CCSP_MESSAGE_BUS_INFO *bus_info =(CCSP_MESSAGE_BUS_INFO *) user_data;
-    const char *interface = dbus_message_get_interface(message);
-    const char *method   = dbus_message_get_member(message);
-    DBusMessage *reply;
-
-    reply = dbus_message_new_method_return (message);
-    if (reply == NULL)
-    {
-        return DBUS_HANDLER_RESULT_HANDLED;
-    }
-
-    return CcspBaseIf_base_path_message_func
-        (
-         conn,
-         message,
-         reply,
-         interface,
-         method,
-         bus_info
-        );
-}
-
 
 ANSC_STATUS
 ssp_Mbi_MessageBusEngage
@@ -129,23 +99,6 @@ ssp_Mbi_MessageBusEngage
     cb.busCheck               = ssp_Mbi_Buscheck;
 
     CcspBaseIf_SetCallback(bus_handle, &cb);
-
-    /* Register service callback functions */
-    returnStatus =
-        CCSP_Message_Bus_Register_Path
-            (
-                bus_handle,
-                path,
-                CcspComp_path_message_func,
-                bus_handle
-            );
-
-    if ( returnStatus != CCSP_Message_Bus_OK )
-    {
-        CcspTraceError((" !!! CCSP_Message_Bus_Register_Path ERROR returnStatus: %ld\n!!!\n", returnStatus));
-
-        return returnStatus;
-    }
 
 
     /* Register event/signal */


### PR DESCRIPTION
RDKBDEV-3075: remove dependency on dbus
Reason for change:Remove dependency on dbus
Test Procedure: Sanity.
Risks: None.
Signed-off-by:
Andre McCurdy amccurdy@libertyglobal.com
SukanyaIlavarasi sukanya.i@tataelxsi.co.in